### PR TITLE
Implement AST printing

### DIFF
--- a/abstract_syntax_tree.py
+++ b/abstract_syntax_tree.py
@@ -1,0 +1,29 @@
+class AbstractSyntaxTree:
+    def __init__(self, root):
+        self.root = root
+
+    def __str__(self):
+        return self.root.accept(self)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
+    def visit_binary(self, binary):
+        return ''.join(['(', ' '.join([
+            binary.left_operand.accept(self),
+            str(binary.operator.literal),
+            binary.right_operand.accept(self),
+        ]), ')'])
+
+    def visit_group(self, group):
+        return ''.join(['Paren(', group.expression.accept(self), ')'])
+
+    def visit_literal(self, literal):
+        return str(literal.value.literal)
+
+    def visit_unary(self, unary):
+        return ''.join([
+            '(', str(unary.operator.literal), unary.operand.accept(self), ')'])

--- a/expression.py
+++ b/expression.py
@@ -13,7 +13,7 @@ class Binary(Expression):
         self.right_operand = right_operand
 
     def accept(self, visitor):
-        visitor.visit_binary(self)
+        return visitor.visit_binary(self)
 
 
 class Group(Expression):
@@ -21,7 +21,7 @@ class Group(Expression):
         self.expression = expression
 
     def accept(self, visitor):
-        visitor.visit_group(self)
+        return visitor.visit_group(self)
 
 
 class Literal(Expression):
@@ -29,7 +29,7 @@ class Literal(Expression):
         self.value = value
 
     def accept(self, visitor):
-        visitor.visit_literal(self)
+        return visitor.visit_literal(self)
 
 
 class Unary(Expression):
@@ -38,4 +38,4 @@ class Unary(Expression):
         self.operand = operand
 
     def accept(self, visitor):
-        visitor.visit_unary(self)
+        return visitor.visit_unary(self)

--- a/parser.py
+++ b/parser.py
@@ -2,6 +2,7 @@ from tokens import TokenType
 import expression
 from error_handler import ErrorHandler
 from error_handler import ParseError
+from abstract_syntax_tree import AbstractSyntaxTree
 
 
 class Parser:
@@ -16,7 +17,7 @@ class Parser:
             return None
 
         try:
-            return self._expression()
+            return AbstractSyntaxTree(self._expression())
         except ParseError as error:
             self.error_handler.report_error(error)
             return None

--- a/test_ast.py
+++ b/test_ast.py
@@ -1,0 +1,87 @@
+import unittest
+from abstract_syntax_tree import AbstractSyntaxTree
+from tokens import Token, TokenType
+from expression import Literal, Unary, Binary
+
+
+class AstTest(unittest.TestCase):
+    def setUp(self):
+        self.tokens = {
+            TokenType.IDENTIFIER: Token(
+                TokenType.IDENTIFIER, 'name', 'identifier', 1),
+            TokenType.INT: Token(TokenType.INT, '1', 1, 1),
+            TokenType.MINUS: Token(TokenType.MINUS, '-', '-', 1),
+            TokenType.NOT: Token(TokenType.NOT, '!', '!', 1),
+            TokenType.ASTERISK: Token(TokenType.ASTERISK, '*', '*', 1),
+            TokenType.DIV: Token(TokenType.DIV, '/', '/', 1),
+            TokenType.PLUS: Token(TokenType.PLUS, '+', '+', 1),
+            TokenType.GTE: Token(TokenType.GTE, '>=', '>=', 1),
+            TokenType.GT: Token(TokenType.GT, '>', '>', 1),
+            TokenType.LTE: Token(TokenType.LTE, '<=', '<=', 1),
+            TokenType.LT: Token(TokenType.LT, '<', '<', 1),
+            TokenType.EQUALITY: Token(TokenType.EQUALITY, '==', '==', 1),
+            TokenType.INEQUALITY: Token(TokenType.INEQUALITY, '!=', '!=', 1)
+        }
+
+    def test_mult_minus(self):
+        self.assertEqual(
+            str(
+                AbstractSyntaxTree(
+                    Binary(
+                        Literal(self.tokens[TokenType.INT]),
+                        self.tokens[TokenType.PLUS],
+                        Binary(
+                            Unary(
+                                self.tokens[TokenType.MINUS],
+                                Literal(self.tokens[TokenType.INT])
+                            ),
+                            self.tokens[TokenType.ASTERISK],
+                            Literal(self.tokens[TokenType.INT])
+                        )
+                    )
+                )
+            ),
+            '(1 + ((-1) * 1))'
+        )
+
+    def test_plus_gt(self):
+        self.assertEqual(
+            str(
+                AbstractSyntaxTree(
+                    Binary(
+                        Binary(
+                            Literal(self.tokens[TokenType.IDENTIFIER]),
+                            self.tokens[TokenType.PLUS],
+                            Literal(self.tokens[TokenType.INT])
+                        ),
+                        self.tokens[TokenType.GT],
+                        Literal(self.tokens[TokenType.INT])
+                    )
+                )
+            ),
+            '((identifier + 1) > 1)'
+        )
+
+    def test_minus_minuses(self):
+        self.assertEqual(
+            str(
+                AbstractSyntaxTree(
+                    Binary(
+                        Unary(
+                            self.tokens[TokenType.MINUS],
+                            Literal(self.tokens[TokenType.IDENTIFIER])
+                        ),
+                        self.tokens[TokenType.MINUS],
+                        Unary(
+                            self.tokens[TokenType.MINUS],
+                            Literal(self.tokens[TokenType.IDENTIFIER])
+                        )
+                    )
+                )
+            ),
+            '((-identifier) - (-identifier))'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_parser.py
+++ b/test_parser.py
@@ -2,6 +2,7 @@ import unittest
 from parser import Parser
 from tokens import Token, TokenType
 from expression import Literal, Unary, Binary
+from abstract_syntax_tree import AbstractSyntaxTree
 
 
 class ParserTest(unittest.TestCase):
@@ -32,7 +33,7 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(Literal(self.tokens[TokenType.INT]))
         )
 
     def test_id_statement(self):
@@ -40,7 +41,7 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Literal(self.tokens[TokenType.IDENTIFIER])
+            AbstractSyntaxTree(Literal(self.tokens[TokenType.IDENTIFIER]))
         )
 
     def test_unary_minus(self):
@@ -51,9 +52,11 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Unary(
-                self.tokens[TokenType.MINUS],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Unary(
+                    self.tokens[TokenType.MINUS],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -65,9 +68,11 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Unary(
-                self.tokens[TokenType.NOT],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Unary(
+                    self.tokens[TokenType.NOT],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -80,10 +85,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.ASTERISK],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.ASTERISK],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -96,10 +103,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.INT]),
-                self.tokens[TokenType.DIV],
-                Literal(self.tokens[TokenType.IDENTIFIER])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.INT]),
+                    self.tokens[TokenType.DIV],
+                    Literal(self.tokens[TokenType.IDENTIFIER])
+                )
             )
         )
 
@@ -113,13 +122,15 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Unary(
-                    self.tokens[TokenType.MINUS],
-                    Literal(self.tokens[TokenType.INT])
-                ),
-                self.tokens[TokenType.DIV],
-                Literal(self.tokens[TokenType.IDENTIFIER])
+            AbstractSyntaxTree(
+                Binary(
+                    Unary(
+                        self.tokens[TokenType.MINUS],
+                        Literal(self.tokens[TokenType.INT])
+                    ),
+                    self.tokens[TokenType.DIV],
+                    Literal(self.tokens[TokenType.IDENTIFIER])
+                )
             )
         )
 
@@ -132,10 +143,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.PLUS],
-                Literal(self.tokens[TokenType.IDENTIFIER])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.PLUS],
+                    Literal(self.tokens[TokenType.IDENTIFIER])
+                )
             )
         )
 
@@ -148,10 +161,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.INT]),
-                self.tokens[TokenType.MINUS],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.INT]),
+                    self.tokens[TokenType.MINUS],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -166,15 +181,17 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Unary(
+            AbstractSyntaxTree(
+                Binary(
+                    Unary(
+                        self.tokens[TokenType.MINUS],
+                        Literal(self.tokens[TokenType.IDENTIFIER])
+                    ),
                     self.tokens[TokenType.MINUS],
-                    Literal(self.tokens[TokenType.IDENTIFIER])
-                ),
-                self.tokens[TokenType.MINUS],
-                Unary(
-                    self.tokens[TokenType.MINUS],
-                    Literal(self.tokens[TokenType.IDENTIFIER])
+                    Unary(
+                        self.tokens[TokenType.MINUS],
+                        Literal(self.tokens[TokenType.IDENTIFIER])
+                    )
                 )
             )
         )
@@ -191,16 +208,18 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.INT]),
-                self.tokens[TokenType.PLUS],
+            AbstractSyntaxTree(
                 Binary(
-                    Unary(
-                        self.tokens[TokenType.MINUS],
+                    Literal(self.tokens[TokenType.INT]),
+                    self.tokens[TokenType.PLUS],
+                    Binary(
+                        Unary(
+                            self.tokens[TokenType.MINUS],
+                            Literal(self.tokens[TokenType.INT])
+                        ),
+                        self.tokens[TokenType.ASTERISK],
                         Literal(self.tokens[TokenType.INT])
-                    ),
-                    self.tokens[TokenType.ASTERISK],
-                    Literal(self.tokens[TokenType.INT])
+                    )
                 )
             )
         )
@@ -214,10 +233,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.GTE],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.GTE],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -230,10 +251,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.GT],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.GT],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -246,10 +269,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.LTE],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.LTE],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -262,10 +287,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.LT],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.LT],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -278,16 +305,20 @@ class ParserTest(unittest.TestCase):
             self.tokens[TokenType.INT]
         ]
 
+        result = self.parser.parse()
+        print(result)
         self.assertEqual(
-            self.parser.parse(),
-            Binary(
+            result,
+            AbstractSyntaxTree(
                 Binary(
-                    Literal(self.tokens[TokenType.IDENTIFIER]),
-                    self.tokens[TokenType.PLUS],
+                    Binary(
+                        Literal(self.tokens[TokenType.IDENTIFIER]),
+                        self.tokens[TokenType.PLUS],
+                        Literal(self.tokens[TokenType.INT])
+                    ),
+                    self.tokens[TokenType.GT],
                     Literal(self.tokens[TokenType.INT])
-                ),
-                self.tokens[TokenType.GT],
-                Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -300,10 +331,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.IDENTIFIER]),
-                self.tokens[TokenType.EQUALITY],
-                Literal(self.tokens[TokenType.INT])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.IDENTIFIER]),
+                    self.tokens[TokenType.EQUALITY],
+                    Literal(self.tokens[TokenType.INT])
+                )
             )
         )
 
@@ -316,10 +349,12 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(
             self.parser.parse(),
-            Binary(
-                Literal(self.tokens[TokenType.INT]),
-                self.tokens[TokenType.INEQUALITY],
-                Literal(self.tokens[TokenType.IDENTIFIER])
+            AbstractSyntaxTree(
+                Binary(
+                    Literal(self.tokens[TokenType.INT]),
+                    self.tokens[TokenType.INEQUALITY],
+                    Literal(self.tokens[TokenType.IDENTIFIER])
+                )
             )
         )
 

--- a/tokens.py
+++ b/tokens.py
@@ -9,10 +9,10 @@ class Token:
         self.source_file_line_number = source_file_line_number
 
     def __str__(self):
-        return '{} {} {}'.format(self.type, self.lexeme, self.literal)
+        return '{} {} {}'.format(self.token_type, self.lexeme, self.literal)
 
     def __repr__(self):
-        return '{} {} {}'.format(self.type, self.lexeme, self.literal)
+        return '{} {} {}'.format(self.token_type, self.lexeme, self.literal)
 
 
 class DataType(Enum):


### PR DESCRIPTION
This commit adds an AbstractSyntaxTree to encapsulate the parser output instead of just passing the root expression node. The first functionality of the AST class is the ability to do a deep comparison to make testing easier and the ability to print out the entire tree in infix notation with each individual expression parenthesized. 