### PR TITLE
Implement interpret_file

### DIFF
--- a/olc
+++ b/olc
@@ -25,7 +25,8 @@ class Orchestrator:
             interpreter.error_handler.log_errors()
 
     def interpret_file(self, filename):
-        pass
+        with open(filename) as file:
+            self.execute(file.read())
 
     def run_repl(self):
         while True:


### PR DESCRIPTION
Uses the python builtins open() and read() on an input file and then executes it as oll source code