### PR TITLE
Implement return statements

### DIFF
--- a/src/abstract_syntax_tree.py
+++ b/src/abstract_syntax_tree.py
@@ -43,7 +43,7 @@ class AbstractSyntaxTree:
         )
 
     def visit_call_expression(self, call_expression):
-        args = map(lambda x: x.value.lexeme, call_expression.arguments)
+        args = map(lambda x: str(x), call_expression.arguments)
         args = ', '.join(args)
         return str(call_expression.callee.name) + '(' + args + ')'
 
@@ -106,7 +106,7 @@ class AbstractSyntaxTree:
         )
 
     def visit_return_statement(self, return_statement):
-        pass
+        return 'RETURN [{}]'.format(return_statement.value)
 
     def visit_class_statement(self, class_statement):
         pass

--- a/src/abstract_syntax_tree.py
+++ b/src/abstract_syntax_tree.py
@@ -43,8 +43,7 @@ class AbstractSyntaxTree:
         )
 
     def visit_call_expression(self, call_expression):
-        args = map(lambda x: str(x), call_expression.arguments)
-        args = ', '.join(args)
+        args = ', '.join(map(lambda x: str(x), call_expression.arguments))
         return str(call_expression.callee.name) + '(' + args + ')'
 
     def visit_get_expression(self, get_expression):

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1,6 +1,6 @@
 from src.constants import AppType
 from src.error_handler import ErrorHandler, InterpretError
-from src.interpreter_runtime import Function
+from src.interpreter_runtime import Function, Return
 from src.interpreter_runtime import RuntimeValue, RuntimeDataType, RuntimeOperators, Environment
 from src.logger import Logger as log
 from src.tokens import TokenType
@@ -86,7 +86,11 @@ class Interpreter:
 
     def visit_return_statement(self, return_statement) -> None:
         log.info(AppType.INTERPRETER, f'visit_return_statement: {return_statement}')
-        pass
+        value = None
+        if return_statement.value:
+            value = self.evaluate_expression(return_statement.value)
+
+        raise Return(value)
 
     def visit_class_statement(self, class_statement) -> None:
         log.info(AppType.INTERPRETER, f'visit_class_statement: {class_statement}')

--- a/src/interpreter_runtime.py
+++ b/src/interpreter_runtime.py
@@ -86,10 +86,18 @@ class Function(RuntimeValue):
         for i in range(len(self.declaration.parameters)):
             environment.define(self.declaration.parameters[i].lexeme, arguments[i])
 
-        interpreter.execute_block(self.declaration.body.statements, environment)
+        try:
+            interpreter.execute_block(self.declaration.body.statements, environment)
+        except Return as _return:
+            return _return.value
 
     def __str__(self):
         return '<function ' + self.declaration.name.lexeme + '>'
+
+
+class Return(Exception):
+    def __init__(self, value):
+        self.value = value
 
 
 class RuntimeOperators:

--- a/src/parser.py
+++ b/src/parser.py
@@ -79,7 +79,7 @@ class Parser:
         if self._is_one_of_types(BLOCK_OPENING_TOKENS):
             return self._parse_block_statement()
         if self._is_one_of_types(RETURN_TOKENS):
-            return self._parse_return_statmeent()
+            return self._parse_return_statement()
         return self._parse_expression_statement()
 
     def _parse_var_statement(self) -> VarStatement:

--- a/src/parser.py
+++ b/src/parser.py
@@ -11,7 +11,8 @@ from src.ast_node_statement import VarStatement, ExpressionStatement, PrintState
 from src.parser_constants import EQUALITY_TOKENS, COMPARISON_TOKENS, TERM_TOKENS, FACTOR_TOKENS, \
     UNARY_TOKENS, LITERAL_TOKENS, IGNORED_TOKENS, GROUP_OPENING_TOKENS, GROUP_CLOSING_TOKENS, \
     STATEMENT_START_TOKENS, STATEMENT_END_TOKENS, IDENTIFIER_TOKENS, EQUALS_TOKENS, \
-    BLOCK_OPENING_TOKENS, BLOCK_CLOSING_TOKENS, VAR_STATEMENT_TOKENS, FUNCTION_STATEMENT_TOKENS, DELIMITER_TOKENS
+    BLOCK_OPENING_TOKENS, BLOCK_CLOSING_TOKENS, VAR_STATEMENT_TOKENS, FUNCTION_STATEMENT_TOKENS, DELIMITER_TOKENS, \
+    RETURN_TOKENS
 
 
 class Parser:
@@ -77,6 +78,8 @@ class Parser:
             return self._parse_print_statement()
         if self._is_one_of_types(BLOCK_OPENING_TOKENS):
             return self._parse_block_statement()
+        if self._is_one_of_types(RETURN_TOKENS):
+            return self._parse_return_statmeent()
         return self._parse_expression_statement()
 
     def _parse_var_statement(self) -> VarStatement:

--- a/src/parser.py
+++ b/src/parser.py
@@ -175,9 +175,14 @@ class Parser:
 
         return FunctionStatement(name, parameters, body)
 
-    def _parse_return_statmeent(self) -> ReturnStatement:
+    def _parse_return_statement(self) -> ReturnStatement:
         log.info(AppType.PARSER, 'Started parsing ReturnStatement')
-        pass
+        keyword = self._peek_prev()
+        value = None
+        if not self._is_same_type(TokenType.SEMICOLON):
+            value = self._expression()
+        self._consume_or_raise(STATEMENT_END_TOKENS, 'Expected semicolon at end of return statement')
+        return ReturnStatement(keyword, value)
 
     def _parse_class_statement(self) -> ClassStatement:
         log.info(AppType.PARSER, 'Started parsing ClassStatement')

--- a/src/parser_constants.py
+++ b/src/parser_constants.py
@@ -83,6 +83,10 @@ STATEMENT_END_TOKENS = {
     TokenType.SEMICOLON
 }
 
+RETURN_TOKENS = {
+    TokenType.RETURN
+}
+
 STATEMENT_START_TOKENS = {
     TokenType.CLASS,
     TokenType.FUNCTION,


### PR DESCRIPTION
This commit implements parsing, interpreting, and printing return statements. In order to interrupt the running procedure and immediately return the value for the return statement, we raise the return value as an Return exception, which is then caught in the _call_function method in order to return the value. Otherwise it implicitly returns None.