### PR TITLE
Deepcopy function closure

### DIFF
--- a/src/interpreter_runtime.py
+++ b/src/interpreter_runtime.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from enum import Enum
 from src.constants import Color, AppType
 from src.logger import Logger as log
@@ -77,7 +78,7 @@ class Function(RuntimeValue):
     def __init__(self, declaration, closure):
         super().__init__(data_type=RuntimeDataType.FUNCTION)
         self.declaration = declaration
-        self.closure = closure
+        self.closure = deepcopy(closure)
 
     def get_arity(self):
         return len(self.declaration.parameters)


### PR DESCRIPTION
Previously function closures were passed by reference. In that case, when the closure environment changed the changes were also reflected inside of the function closure, since it was a reference to the same object. This change makes a copy of the closure, which is a snapshot of the environment at the point of time when the function was defined and would only change from statements inside the function itself.