### PR TITLE
Implement for loop syntax

### DIFF
--- a/src/lexer_constants.py
+++ b/src/lexer_constants.py
@@ -9,6 +9,7 @@ RESERVED_WORDS = {
     'else': TokenType.ELSE,
     'elif': TokenType.ELIF,
     'while': TokenType.WHILE,
+    'for': TokenType.FOR,
     'print': TokenType.PRINT,
     'include': TokenType.INCLUDE,
     'class': TokenType.CLASS,

--- a/src/parser_constants.py
+++ b/src/parser_constants.py
@@ -93,6 +93,7 @@ STATEMENT_START_TOKENS = {
     TokenType.VAR,
     TokenType.IF,
     TokenType.WHILE,
+    TokenType.FOR,
     TokenType.PRINT,
     TokenType.RETURN,
 }

--- a/src/tokens.py
+++ b/src/tokens.py
@@ -103,6 +103,7 @@ class TokenType(Enum):
     ELSE = 'else'
     ELIF = 'elif'
     WHILE = 'while'
+    FOR = 'for'
     PRINT = 'print'
     INCLUDE = 'include'
     CLASS = 'class'


### PR DESCRIPTION
This PR implements the for standard C-liked for loop syntax for OLL. It adds a FOR TokenType to the lexer, and in the parser it treats the for loop as syntactic sugar and coverts it into a while statement in the syntax tree, so that no update to the interpreter was required.